### PR TITLE
Improve cljs require support. Add cljs tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dev-src/public/main.js
 dev-src/public/main.out
 .*
 !.gitignore
+cljs-test-runner-out/

--- a/deps.edn
+++ b/deps.edn
@@ -13,6 +13,11 @@
                   :main-opts ["prod.clj"]}
            :test {:extra-paths ["test"]
                   :main-opts ["test.clj"]}
+           :test-cljs {:extra-paths ["test"]
+                       :extra-deps {olical/cljs-test-runner {:mvn/version "3.7.0"}
+                                    org.clojure/test.check {:mvn/version "1.1.0"}}
+                       :main-opts ["-m" "cljs-test-runner.main"
+                                   "-d" "test"]}
            :bench {:extra-deps {net.sekao/clarax {:mvn/version "0.4.1"}
                                 datascript/datascript {:mvn/version "1.0.1"}
                                 com.clojure-goes-fast/clj-async-profiler {:mvn/version "0.5.0"}}

--- a/src/odoyle/rules.cljc
+++ b/src/odoyle/rules.cljc
@@ -2,6 +2,8 @@
   (:require [clojure.spec.alpha :as s]
             [expound.alpha :as expound]
             [clojure.string :as str])
+  #?(:cljs
+      (:require-macros [odoyle.rules :refer [ruleset]]))
   (:refer-clojure :exclude [reset!]))
 
 ;; parsing
@@ -618,7 +620,8 @@
         ;; assoc'ed by add-condition
         (dissoc :mem-node-ids :join-node-ids :bindings))))
 
-(defmacro ruleset
+#?(:clj
+ (defmacro ruleset
   "Returns a vector of rules after transforming the given map."
   [rules]
   (reduce
@@ -632,7 +635,7 @@
                        ~(when then-finally-body
                           `(fn ~fn-name [] ~@then-finally-body)))))
     []
-    (mapv ->rule (parse ::rules rules))))
+    (mapv ->rule (parse ::rules rules)))))
 
 (defn ->session
   "Returns a new session."

--- a/test/odoyle/rules_test.cljc
+++ b/test/odoyle/rules_test.cljc
@@ -1,5 +1,5 @@
 (ns odoyle.rules-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is]]
             [odoyle.rules :as o]
             [clojure.spec.test.alpha :as st]))
 
@@ -795,5 +795,6 @@
       (o/insert ::alice ::color "red")
       (o/insert ::bob ::color "blue")
       ((fn [session]
-        (is (thrown? Exception (o/fire-rules session)))))))
+        (is (thrown? #?(:clj Exception :cljs js/Error)
+                     (o/fire-rules session)))))))
 


### PR DESCRIPTION
- changed rules.cljc to allow clients to use basic require instead of
  require-macros and reader conditionals
- moved rules-test.clj -> rules-test.cljc and generalised for cljs
  testing
- added :test-cljs alias
  -- to test run clj -M:test-cljs

- added cljs-test-runner-out to .gitignore
